### PR TITLE
Add BvC, HLvLF and 2D to TT2L, e/ctag_DY, and e/ctag_Wc workflows, small fixes

### DIFF
--- a/scripts/fetch.py
+++ b/scripts/fetch.py
@@ -1531,7 +1531,7 @@ def validate(file):
             return fin["Events"].num_entries
         except:
             print("retries", n_tries, file)
-            n_tries += n_tries
+            n_tries += 1
     if not_able_open:
         return f"FailedRetries: {file}"
 

--- a/scripts/plotdataMC.py
+++ b/scripts/plotdataMC.py
@@ -164,7 +164,7 @@ elif "ectag" in args.phase or "2D_e_" in args.phase:
     input_txt = input_txt + " (e)"
 elif "QCD" == args.phase:
     input_txt = input_txt + ""
-elif "ttdilep_sf" == args.phase:
+elif "ttdilep_sf" in args.phase:
     input_txt = input_txt + " (e$\mu$)"
 else:
     input_txt = input_txt + " ($\mu$)"
@@ -250,7 +250,7 @@ for index, discr in enumerate(var_set):
             for i in range(collated["mc"][discr].axes[0].size)
         ]
         if "noSF" in systlist:
-            noSF_axis["syst"] = "nominal"
+            noSF_axis["syst"] = "noSF"
 
     ## rebin config, add xerr
     do_xerr = False

--- a/src/BTVNanoCommissioning/helpers/definitions.py
+++ b/src/BTVNanoCommissioning/helpers/definitions.py
@@ -6412,6 +6412,8 @@ def axes_name(var):
             unit = unit + " CvB"
         elif "CvNotB" in var:
             unit = unit + " CvNotB"
+        elif "BvCt" in var:
+            unit = unit + " BvCt"
         elif "BvC" in var:
             unit = unit + " BvC"
         elif "B_b" in var or "ProbB" in var:
@@ -6422,6 +6424,8 @@ def axes_name(var):
             unit = unit + " Prob(lepb)"
         elif "B_lepb" in var:
             unit = unit + " Prob(lepb)"
+        elif "HFvLFt" in var:
+            unit = unit + " HFvLFt"
         elif "HFvLF" in var:
             unit = unit + " HFvLF"
         elif "2D" in var:

--- a/src/BTVNanoCommissioning/utils/plot_utils.py
+++ b/src/BTVNanoCommissioning/utils/plot_utils.py
@@ -56,7 +56,10 @@ sample_mergemap = {
     "VV": [
         "WW_TuneCP5_13p6TeV-pythia8",
         "WZ_TuneCP5_13p6TeV-pythia8",
-        "ZZ_TuneCP5_13p6TeV-pythia8"
+        "ZZ_TuneCP5_13p6TeV-pythia8",
+        "WW_TuneCP5_13p6TeV_pythia8",
+        "WZ_TuneCP5_13p6TeV_pythia8",
+        "ZZ_TuneCP5_13p6TeV_pythia8"
         # decay
         "ZZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
         "ZZto2Nu2Q_TuneCP5_13p6TeV_powheg-pythia8",

--- a/src/BTVNanoCommissioning/utils/sample.py
+++ b/src/BTVNanoCommissioning/utils/sample.py
@@ -47,6 +47,62 @@ predefined_sample = {
         "MC": ["DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8"],
         "minor_MC": ["TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8"],
     },
+    "2D_mu_DY_sf": {
+        "data": ["Muon0", "Muon1"],
+        "MC": [
+            "DYto2E-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            "DYto2Mu-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            "DYto2Tau-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8]",
+        ],
+        "minor_MC": [
+            # TT
+            "TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            # Single Top
+            "TbarBQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TBbarQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8", 
+            "TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8",
+            # VV    
+            "WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8",
+			"WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto4L_TuneCP5_13p6TeV_powheg-pythia8",
+        ], 
+    },
+    "2D_e_DY_sf": {
+        "data": ["EGamma0", "EGamma1"],
+        "MC": [
+            "DYto2E-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            "DYto2Mu-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            "DYto2Tau-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8]",
+        ],
+        "minor_MC": [
+            # TT
+            "TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            # Single Top
+            "TbarBQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TBbarQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8", 
+            "TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8",
+            # VV    
+            "WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8",
+			"WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto4L_TuneCP5_13p6TeV_powheg-pythia8",
+        ], 
+    },
     "emctag_ttdilep_sf": {
         "data": ["MuonEG"],
         "MC": ["TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8"],
@@ -68,6 +124,32 @@ predefined_sample = {
             "WW_TuneCP5_13p6TeV_pythia8",
             "TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
         ],
+    },
+    "2D_emu_ttdilep_sf": {
+        "data": ["MuonEG"], 
+        "MC": ["TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8"],
+        "minor_MC": [
+            # TT
+            "TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            # Single Top
+            "TbarBQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TBbarQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8", 
+            "TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8",      
+            # VV
+            "WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto4L_TuneCP5_13p6TeV_powheg-pythia8",
+        ], 
     },
     "ctag_ttdilep_sf": {
         "data": ["Muon0", "Muon1"],
@@ -282,6 +364,76 @@ predefined_sample = {
             "ZZto4L_TuneCP5_13p6TeV_powheg-pythia8",
         ],
         "minor_MC": [],
+    },
+    "2D_mu_Wc_sf": {
+        "data": ["Muon0", "Muon1"],
+        "MC": [
+            "WtoENu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8",
+            "WtoMuNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8",
+            "WtoTauNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8",
+        ],
+        "minor_MC": [
+            # TT
+            "TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            # Single Top
+            "TbarBQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TBbarQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            # DY
+            "DYto2E-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            "DYto2Mu-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            "DYto2Tau-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            # VV
+            "WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto4L_TuneCP5_13p6TeV_powheg-pythia8",
+        ],
+    },
+    "2D_e_Wc_sf": {
+        "data": ["EGamma0", "EGamma1"],
+        "MC": [
+            "WtoENu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8",
+            "WtoMuNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8",
+            "WtoTauNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8",
+        ],
+        "minor_MC": [
+            # TT
+            "TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            # Single Top
+            "TbarBQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TBbarQtoLNu-t-channel-4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8",
+            "TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            # DY
+            "DYto2E-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            "DYto2Mu-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            "DYto2Tau-2Jets_Bin-MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8",
+            # VV
+            "WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8",
+            "ZZto4L_TuneCP5_13p6TeV_powheg-pythia8",
+        ],
     },
     "BTA": {
         "data": ["JetMET0", "JetMET1"],

--- a/src/BTVNanoCommissioning/utils/selection.py
+++ b/src/BTVNanoCommissioning/utils/selection.py
@@ -212,9 +212,9 @@ def get_wp_2D(ith_jet_HFvLF_val, ith_jet_BvC_val, year, campaign, tagger):
         HFvLF_high = WP[tagger]["2D"][wp][1]
         BvC_low = WP[tagger]["2D"][wp][2]
         BvC_high = WP[tagger]["2D"][wp][3]
-        if ith_jet_HFvLF_val is None or ith_jet_BvC_val == None:
+        if ith_jet_HFvLF_val is None or ith_jet_BvC_val is None:
             return None
-        if ith_jet_HFvLF_val is -1 or ith_jet_BvC_val == -1:
+        if ith_jet_HFvLF_val == -1 or ith_jet_BvC_val == -1:
             return -1.0
         if HFvLF_low == 0:
             passWP = (ith_jet_HFvLF_val >= HFvLF_low)

--- a/src/BTVNanoCommissioning/workflows/__init__.py
+++ b/src/BTVNanoCommissioning/workflows/__init__.py
@@ -59,6 +59,9 @@ workflows["validation"] = ValidationProcessor
 
 # TTBar
 workflows["ttdilep_sf"] = TTdilepValidSFProcessor
+workflows["2D_emu_ttdilep_sf"] = partial(
+    TTdilepValidSFProcessor, selectionModifier="ttdilep_sf_2D"
+)
 workflows["ttsemilep_sf"] = partial(
     TTsemilepValidSFProcessor, selectionModifier="tt_semilep"
 )
@@ -97,7 +100,13 @@ workflows["ctag_Wc_sf"] = partial(CTAGWcTTValidSFProcessor, selectionModifier="W
 workflows["ctag_Wc_noMuVeto_sf"] = partial(
     CTAGWcTTValidSFProcessor, selectionModifier="WcM_noMuVeto"
 )
+workflows["2D_mu_Wc_sf"] = partial(
+    CTAGWcTTValidSFProcessor, selectionModifier="WcM_2D"
+)
 workflows["ectag_Wc_sf"] = partial(CTAGWcTTValidSFProcessor, selectionModifier="WcE")
+workflows["2D_e_Wc_sf"] = partial(
+    CTAGWcTTValidSFProcessor, selectionModifier="WcE_2D"
+)
 workflows["ctag_Wc_WP_sf"] = partial(
     CTAGWcTTValidSFProcessor, selectionModifier="cutbased_WcM"
 )
@@ -108,6 +117,13 @@ workflows["ectag_Wc_WP_sf"] = partial(
 # DY
 workflows["ctag_DY_sf"] = partial(CTAGDYValidSFProcessor, selectionModifier="DYM")
 workflows["ectag_DY_sf"] = partial(CTAGDYValidSFProcessor, selectionModifier="DYE")
+workflows["2D_mu_DY_sf"] = partial(
+    CTAGDYValidSFProcessor, selectionModifier="DYM_2D"
+)
+workflows["2D_e_DY_sf"] = partial(
+    CTAGDYValidSFProcessor, selectionModifier="DYE_2D"
+)
+
 
 # Tutorial
 # workflows["example"] = ExampleProcessor

--- a/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_DY_valid_sf.py
@@ -22,6 +22,9 @@ from BTVNanoCommissioning.utils.selection import (
     mu_idiso,
     ele_mvatightid,
     MET_filters,
+    calculate_new_discriminators,
+    get_wp_2D,
+    btag_wp_dict
 )
 
 
@@ -77,7 +80,12 @@ class NanoProcessor(processor.ProcessorABC):
         else:
             raise ValueError(self.selMod, "is not a valid selection modifier.")
 
-        histname = {"DYM": "ctag_DY_sf", "DYE": "ectag_DY_sf"}
+        histname = {
+            "DYM": "ctag_DY_sf",
+            "DYE": "ectag_DY_sf",
+            "DYM_2D": "ctag_DY_sf_2D",
+            "DYE_2D": "ectag_DY_sf_2D",
+        }
         output = {} if self.noHist else histogrammer(events, histname[self.selMod])
 
         if isRealData:
@@ -236,6 +244,21 @@ class NanoProcessor(processor.ProcessorABC):
         if "PFCands" in events.fields:
             pruned_ev["PFCands"] = PFCand_link(events, event_level, jetindx)
 
+        if "2D" in self.selMod:
+            pruned_ev["dilep", "ptratio"] = pruned_ev.dilep.pt / sel_jet.pt
+            nj = 1
+            for i in range(nj):
+                btagUParTAK4HFvLF, btagUParTAK4BvC = calculate_new_discriminators(pruned_ev.SelJet[:, i])
+                wp2D = ak.Array([get_wp_2D(btagUParTAK4HFvLF[i], btagUParTAK4BvC[i], self._year, self._campaign, "UParTAK4") for i in range(len(btagUParTAK4HFvLF))])
+                pruned_ev[f"btagUParTAK4HFvLF_{i}"] = btagUParTAK4HFvLF
+                pruned_ev[f"btagUParTAK4BvC_{i}"] = btagUParTAK4BvC
+                pruned_ev[f"btagUParTAK4HFvLFt_{i}"] = ak.Array(np.where(btagUParTAK4HFvLF > 0.0, 1.0 - (1.0 - btagUParTAK4HFvLF)**0.5, -1.0))
+                pruned_ev[f"btagUParTAK4BvCt_{i}"] = ak.Array(np.where(btagUParTAK4BvC > 0.0, 1.0 - (1.0 - btagUParTAK4BvC)**0.5, -1.0))
+                pruned_ev[f"btagUParTAK42D_{i}"] = wp2D     
+                jet_pt_bins = btag_wp_dict[self._year + "_" + self._campaign]["UParTAK4"]["2D"]["jet_pt_bins"]
+                for jet_pt_bin in jet_pt_bins:
+                    pruned_ev[f"btagUParTAK42D_pt{jet_pt_bin[0]}to{jet_pt_bin[1]}_{i}"] = [wp2D[ijet] if pt is not None and jet_pt_bin[0] < pt and pt < jet_pt_bin[1] else None for ijet, pt in enumerate(pruned_ev.SelJet[:, i].pt)]
+    
         ####################
         #     Output       #
         ####################

--- a/src/BTVNanoCommissioning/workflows/ctag_Wctt_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ctag_Wctt_valid_sf.py
@@ -22,6 +22,9 @@ from BTVNanoCommissioning.utils.selection import (
     softmu_mask,
     btag_wp,
     btag_wp_dict,
+    btag_wp,
+    calculate_new_discriminators,
+    get_wp_2D,
 )
 
 
@@ -98,6 +101,8 @@ class NanoProcessor(processor.ProcessorABC):
             "WcE": "ectag_Wc_sf",
             "cutbased_WcM": "ctag_cutbased_Wc_sf",
             "cutbased_WcE": "ectag_cutbased_Wc_sf",
+            "WcM_2D" : "ctag_Wc_sf_2D",
+            "WcE_2D" : "ectag_Wc_sf_2D",
             "semittM": "ctag_Wc_sf",  # same histogram representation as W+c, since only nJet is different
             "semittE": "ectag_Wc_sf",  # same histogram representation as W+c, since only nJet is different
             "WcM_noMuVeto": "ctag_Wc_sf",
@@ -349,7 +354,7 @@ class NanoProcessor(processor.ProcessorABC):
         sz = shmu + ssmu
         sw = shmu + smet
 
-        osss = 1
+        osss = shmu.charge * ssmu.charge * -1
         ossswrite = shmu.charge * ssmu.charge * -1
         smuon_jet_passc = {}
         c_algos = []
@@ -375,7 +380,7 @@ class NanoProcessor(processor.ProcessorABC):
         # Keep the structure of events and pruned the object size
         pruned_ev = events[event_level]
         pruned_ev["SelJet"] = sjets
-        if self.selMod.endswith("M"):
+        if self.selMod.endswith("M") or self.selMod == "WcM_2D":
             pruned_ev["SelMuon"] = shmu
         else:
             pruned_ev["SelElectron"] = shmu
@@ -428,6 +433,21 @@ class NanoProcessor(processor.ProcessorABC):
             genflavor = ak.ones_like(pruned_ev.SelJet.pt, dtype=int)
             if "MuonJet" in pruned_ev.fields:
                 smflav = ak.ones_like(pruned_ev.MuonJet.pt, dtype=int)
+
+        if "2D" in self.selMod:
+            nj=1
+            for i in range(nj):
+                btagUParTAK4HFvLF, btagUParTAK4BvC = calculate_new_discriminators(pruned_ev.MuonJet)
+                wp2D = ak.Array([get_wp_2D(btagUParTAK4HFvLF[i], btagUParTAK4BvC[i], self._year, self._campaign, "UParTAK4") for i in range(len(btagUParTAK4HFvLF))])
+                pruned_ev[f"btagUParTAK4HFvLF_{i}"] = btagUParTAK4HFvLF
+                pruned_ev[f"btagUParTAK4BvC_{i}"] = btagUParTAK4BvC
+                pruned_ev[f"btagUParTAK4HFvLFt_{i}"] = ak.Array(np.where(btagUParTAK4HFvLF > 0.0, 1.0 - (1.0 - btagUParTAK4HFvLF)**0.5, -1.0))
+                pruned_ev[f"btagUParTAK4BvCt_{i}"] = ak.Array(np.where(btagUParTAK4BvC > 0.0, 1.0 - (1.0 - btagUParTAK4BvC)**0.5, -1.0))
+                pruned_ev[f"btagUParTAK42D_{i}"] = wp2D     
+                jet_pt_bins = btag_wp_dict[self._year + "_" + self._campaign]["UParTAK4"]["2D"]["jet_pt_bins"]
+                for jet_pt_bin in jet_pt_bins:
+                    pruned_ev[f"btagUParTAK42D_pt{jet_pt_bin[0]}to{jet_pt_bin[1]}_{i}"] = [wp2D[ijet] if pt is not None and jet_pt_bin[0] < pt and pt < jet_pt_bin[1] else None for ijet, pt in enumerate(pruned_ev.MuonJet.pt)]
+            
         ####################
         # Weight & Geninfo #
         ####################
@@ -529,26 +549,16 @@ class NanoProcessor(processor.ProcessorABC):
                         weight=weight,
                     )
                 elif "btag" in histname and "Trans" not in histname:
-                    for i in range(2):
-                        if (
-                            str(i) not in histname
-                            or histname.replace(f"_{i}", "") not in events.Jet.fields
+                    if (
+                        "BvC" not in histname
+                        and "HFvLF" not in histname
+                        and "2D" not in histname
                         ):
-                            continue
-                        h.fill(
-                            syst="noSF",
-                            flav=smflav,
-                            osss=osss,
-                            discr=np.where(
-                                smuon_jet[histname.replace(f"_{i}", "")] < 0,
-                                -0.2,
-                                smuon_jet[histname.replace(f"_{i}", "")],
-                            ),
-                            weight=weights.partial_weight(exclude=exclude_btv),
-                        )
-                        if not isRealData and "btag" in self.SF_map.keys():
+                        for i in range(2):
+                            if not histname.endswith(str(i)) or histname.replace(f"_{i}", "") not in smuon_jet.fields:
+                                    continue
                             h.fill(
-                                syst=syst,
+                                syst="noSF",
                                 flav=smflav,
                                 osss=osss,
                                 discr=np.where(
@@ -556,8 +566,38 @@ class NanoProcessor(processor.ProcessorABC):
                                     -0.2,
                                     smuon_jet[histname.replace(f"_{i}", "")],
                                 ),
-                                weight=weight,
+                                weight=weights.partial_weight(exclude=exclude_btv),
                             )
+                            if not isRealData and "btag" in self.SF_map.keys():
+                                h.fill(
+                                    syst=syst,
+                                    flav=smflav,
+                                    osss=osss,
+                                    discr=np.where(
+                                        smuon_jet[histname.replace(f"_{i}", "")] < 0,
+                                        -0.2,
+                                        smuon_jet[histname.replace(f"_{i}", "")],
+                                    ),
+                                    weight=weight,
+                                )
+                    else:
+                        discr_to_plot = pruned_ev[histname]
+                        flav_to_plot = smflav
+                        osss_to_plot = osss
+                        weight_to_plot = weights.partial_weight(exclude=exclude_btv),
+                        discr_mask = [False if x is None else True for x in discr_to_plot]
+                        if ak.any(np.invert(discr_mask)):
+                            flav_to_plot = flav_to_plot[discr_mask]
+                            osss_to_plot = osss_to_plot[discr_mask]
+                            discr_to_plot = discr_to_plot[discr_mask]
+                            weight_to_plot = weight[discr_mask]
+                        h.fill(
+                            syst=syst,
+                            flav=flav_to_plot,
+                            osss=osss_to_plot,
+                            discr=discr_to_plot,
+                            weight=weight_to_plot
+                        )
                 elif "btag" in histname and "Trans" in histname:
                     if histname not in smuon_jet:
                         continue

--- a/src/BTVNanoCommissioning/workflows/ttdilep_valid_sf.py
+++ b/src/BTVNanoCommissioning/workflows/ttdilep_valid_sf.py
@@ -24,7 +24,9 @@ from BTVNanoCommissioning.utils.selection import (
     jet_id,
     mu_idiso,
     ele_cuttightid,
-    btag_wp,
+    calculate_new_discriminators,
+    get_wp_2D,
+    btag_wp_dict,
 )
 
 
@@ -38,6 +40,7 @@ class NanoProcessor(processor.ProcessorABC):
         isArray=False,
         noHist=False,
         chunksize=75000,
+        selectionModifier="tt_dilep",
     ):
         self._year = year
         self._campaign = campaign
@@ -47,6 +50,7 @@ class NanoProcessor(processor.ProcessorABC):
         self.noHist = noHist
         self.lumiMask = load_lumi(self._campaign)
         self.chunksize = chunksize
+        self.selMod = selectionModifier
         ## Load corrections
         self.SF_map = load_SF(self._year, self._campaign)
 
@@ -68,7 +72,10 @@ class NanoProcessor(processor.ProcessorABC):
         dataset = events.metadata["dataset"]
         isRealData = not hasattr(events, "genWeight")
         ## Create histograms
-        output = {} if self.noHist else histogrammer(events, "ttdilep_sf")
+        if self.selMod == "ttdilep_sf_2D":
+            output = {} if self.noHist else histogrammer(events, "ttdilep_sf_2D")
+        else:
+            output = {} if self.noHist else histogrammer(events, "ttdilep_sf")
 
         if shift_name is None:
             if isRealData:
@@ -144,6 +151,18 @@ class NanoProcessor(processor.ProcessorABC):
         jetindx = ak.pad_none(jetindx, 2)
         jetindx = jetindx[:, :2]
 
+        ## MET
+        if self.selMod == "ttdilep_sf_2D":
+            event_MET = ak.zip(
+                {
+                    "pt": events.PuppiMET.pt,
+                    "eta": ak.zeros_like(events.PuppiMET.pt),
+                    "phi": events.PuppiMET.phi,
+                    "mass": ak.zeros_like(events.PuppiMET.pt),
+                },
+                with_name="PtEtaPhiMLorentzVector",
+            )
+
         event_level = (
             req_trig & req_lumi & req_muon & req_ele & req_jets & req_opposite_charge
         )
@@ -176,6 +195,21 @@ class NanoProcessor(processor.ProcessorABC):
         # Find the PFCands associate with selected jets. Search from jetindex->JetPFCands->PFCand
         if "PFCands" in events.fields:
             pruned_ev.PFCands = PFCand_link(events, event_level, jetindx)
+
+        if self.selMod == "ttdilep_sf_2D":
+            nj = 2
+            pruned_ev["MET"] = event_MET[event_level]
+            for i in range(nj):
+                btagUParTAK4HFvLF, btagUParTAK4BvC = calculate_new_discriminators(pruned_ev.SelJet[:, i])
+                wp2D = ak.Array([get_wp_2D(btagUParTAK4HFvLF[i], btagUParTAK4BvC[i], self._year, self._campaign, "UParTAK4") for i in range(len(btagUParTAK4HFvLF))])
+                pruned_ev[f"btagUParTAK4HFvLF_{i}"] = btagUParTAK4HFvLF
+                pruned_ev[f"btagUParTAK4BvC_{i}"] = btagUParTAK4BvC
+                pruned_ev[f"btagUParTAK4HFvLFt_{i}"] = ak.Array(np.where(btagUParTAK4HFvLF > 0.0, 1.0 - (1.0 - btagUParTAK4HFvLF)**0.5, -1.0))
+                pruned_ev[f"btagUParTAK4BvCt_{i}"] = ak.Array(np.where(btagUParTAK4BvC > 0.0, 1.0 - (1.0 - btagUParTAK4BvC)**0.5, -1.0))
+                pruned_ev[f"btagUParTAK42D_{i}"] = wp2D
+                jet_pt_bins = btag_wp_dict[self._year + "_" + self._campaign]["UParTAK4"]["2D"]["jet_pt_bins"]
+                for jet_pt_bin in jet_pt_bins:
+                    pruned_ev[f"btagUParTAK42D_pt{jet_pt_bin[0]}to{jet_pt_bin[1]}_{i}"] = [wp2D[ijet] if pt is not None and jet_pt_bin[0] < pt and pt < jet_pt_bin[1] else None for ijet, pt in enumerate(pruned_ev.SelJet[:, i].pt)]
 
         ####################
         #     Output       #


### PR DESCRIPTION
* Add 2D calibration variables with selection modifier for TT2L, e/ctag_DY, and e/ctag_Wc workflows
* fetch.py: fix loop in validate()
* plotdataMC: adjust phase space label for 2D selection Modifier, fix plotting of syst-axis for "noSF"
* definitions: fix for HVvLFt and BvCt
* plot_utils.py: add naming for 23/24 WZ, WW, ZZ sample